### PR TITLE
Fixed typo in scale calibration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Although other libraries exist, I needed a slightly different approach, so here'
 How to Calibrate Your Scale
 
 1. Call set_scale() with no parameter.
-2. Call set_tare() with no parameter.
+2. Call tare() with no parameter.
 3. Place a known weight on the scale and call get_units(10).
 4. Divide the result in step 3 to your known weight. You should get about the parameter you need to pass to set_scale.
 5. Adjust the parameter in step 4 until you get an accurate reading.


### PR DESCRIPTION
Command to tare is "tare()" not "set_tare"