### PR TITLE
Correctly handle two's compliment value 

### DIFF
--- a/HX711.cpp
+++ b/HX711.cpp
@@ -43,13 +43,9 @@ long HX711::read() {
 	byte data[3];
 
 	// pulse the clock pin 24 times to read the data
-	for (byte j = 3; j--;) {
-		for (char i = 8; i--;) {
-			digitalWrite(PD_SCK, HIGH);
-			bitWrite(data[j], i, digitalRead(DOUT));
-			digitalWrite(PD_SCK, LOW);
-		}
-	}
+    data[2] = shiftIn(DOUT, PD_SCK, MSBFIRST);
+    data[1] = shiftIn(DOUT, PD_SCK, MSBFIRST);
+    data[0] = shiftIn(DOUT, PD_SCK, MSBFIRST);
 
 	// set the channel and the gain factor for the next reading using the clock pin
 	for (int i = 0; i < GAIN; i++) {

--- a/HX711.cpp
+++ b/HX711.cpp
@@ -64,6 +64,8 @@ long HX711::read() {
     // Replicate the most significant bit to pad out a 32-bit signed integer
     if ( data[2] & 0x80 ) {
         filler = 0xFF;
+    } else if ((0x7F == data[2]) && (0xFF == data[1]) && (0xFF == data[0])) {
+        filler = 0xFF;
     } else {
         filler = 0x00;
     }

--- a/HX711.cpp
+++ b/HX711.cpp
@@ -40,7 +40,9 @@ long HX711::read() {
 	// wait for the chip to become ready
 	while (!is_ready());
 
-	byte data[3];
+    unsigned long value = 0;
+    byte data[3] = { 0 };
+    byte filler = 0x00;
 
 	// pulse the clock pin 24 times to read the data
     data[2] = shiftIn(DOUT, PD_SCK, MSBFIRST);
@@ -48,14 +50,32 @@ long HX711::read() {
     data[0] = shiftIn(DOUT, PD_SCK, MSBFIRST);
 
 	// set the channel and the gain factor for the next reading using the clock pin
-	for (int i = 0; i < GAIN; i++) {
+	for (unsigned int i = 0; i < GAIN; i++) {
 		digitalWrite(PD_SCK, HIGH);
 		digitalWrite(PD_SCK, LOW);
 	}
 
-	data[2] ^= 0x80;
+    // Datasheet indicates the value is returned as a two's complement value
+    // Flip all the bits
+    data[2] = ~data[2];
+    data[1] = ~data[1];
+    data[0] = ~data[0];
 
-	return ((uint32_t) data[2] << 16) | ((uint32_t) data[1] << 8) | (uint32_t) data[0];
+    // Replicate the most significant bit to pad out a 32-bit signed integer
+    if ( data[2] & 0x80 ) {
+        filler = 0xFF;
+    } else {
+        filler = 0x00;
+    }
+
+    // Construct a 32-bit signed integer
+    value = ( static_cast<unsigned long>(filler) << 24
+            | static_cast<unsigned long>(data[2]) << 16
+            | static_cast<unsigned long>(data[1]) << 8
+            | static_cast<unsigned long>(data[0]) );
+
+    // ... and add 1
+    return static_cast<long>(++value);
 }
 
 long HX711::read_average(byte times) {


### PR DESCRIPTION
The example in the datasheet demonstrates XOR'ing the resulting value with 0x800000, just as you have done. However, the datasheet reports a 2's compliment number is returned from the sensor, and makes no mention of needing to XOR the result with 0x800000. I've been scratching my head and it seems like the XOR with 0x800000 would only flip the sign bit along with the undesired result of leaving a value of (-1)(1 - x/SIGNED_MAX)* of it's actual value. To convert a 2's complement to a signed integer, then you need to flip all the bits and add one.

**Example:*
```
### - U - 2's - (^0x4)
000 - 0 -  0  -   -4
001 - 1 -  1  -   -3
010 - 2 -  2  -   -2
011 - 3 -  3  -   -1
100 - 4 - -4  -    0
101 - 5 - -3  -    1
110 - 6 - -2  -    2
111 - 7 - -1  -    3
```