### PR TITLE
Adding library.json for usage with platformio

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,17 @@
+{
+    "name": "HX711",
+    "keywords": "hx711, scale, weight",
+    "description": "An Arduino library to interface the Avia Semiconductor HX711 24-Bit Analog-to-Digital Converter (ADC) for Weight Scales.",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/bogde/HX711.gitt"
+    },
+    "version": "0.1",
+    "exclude": "tests",
+    "examples": "examples/*/*.ino",
+    "frameworks": "arduino",
+    "platforms": [
+        "atmelavr",
+        "espressif"
+    ]
+}

--- a/library.json
+++ b/library.json
@@ -4,7 +4,7 @@
     "description": "An Arduino library to interface the Avia Semiconductor HX711 24-Bit Analog-to-Digital Converter (ADC) for Weight Scales.",
     "repository": {
         "type": "git",
-        "url": "https://github.com/bogde/HX711.gitt"
+        "url": "https://github.com/bogde/HX711.git"
     },
     "version": "0.1",
     "exclude": "tests",


### PR DESCRIPTION
For the usage of the library with platformio, a file called library.json is required. See: http://docs.platformio.org/en/latest/librarymanager/config.html. This is my attempt of creating it.