### PR TITLE
Fixing #29, Travis CI integration and ESP8266 Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ install:
     - pip install -U platformio
 
 script:
-    - platformio ci --board=esp12e --board=megaatmega2560 --lib="."
+    - platformio ci --board=megaatmega2560 --lib="."

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: python
+python:
+    - "2.7"
+
+# Cache PlatformIO packages using Travis CI container-based infrastructure
+sudo: false
+cache:
+    directories:
+        - "~/.platformio"
+
+env:
+    - PLATFORMIO_CI_SRC=examples/HX711Serial
+    - PLATFORMIO_CI_SRC=examples/HX711SerialBegin
+
+install:
+    - pip install -U platformio
+
+script:
+    - platformio ci --board=esp12e --board=megaatmega2560 --lib="."

--- a/HX711.cpp
+++ b/HX711.cpp
@@ -2,17 +2,24 @@
 #include <HX711.h>
 
 HX711::HX711(byte dout, byte pd_sck, byte gain) {
-	PD_SCK 	= pd_sck;
-	DOUT 	= dout;
+	begin(dout, pd_sck, gain);
+}
+
+HX711::HX711() {
+}
+
+HX711::~HX711() {
+
+}
+
+void HX711::begin(byte dout, byte pd_sck, byte gain) {
+	PD_SCK = pd_sck;
+	DOUT   = dout;
 
 	pinMode(PD_SCK, OUTPUT);
 	pinMode(DOUT, INPUT);
 
 	set_gain(gain);
-}
-
-HX711::~HX711() {
-
 }
 
 bool HX711::is_ready() {
@@ -38,7 +45,10 @@ void HX711::set_gain(byte gain) {
 
 long HX711::read() {
 	// wait for the chip to become ready
-	while (!is_ready());
+	while (!is_ready()) {
+		// Will do nothing on Arduino but prevent resets of ESP8266 (Watchdog Issue)
+		yield();
+	}
 
     unsigned long value = 0;
     byte data[3] = { 0 };
@@ -84,6 +94,7 @@ long HX711::read_average(byte times) {
 	long sum = 0;
 	for (byte i = 0; i < times; i++) {
 		sum += read();
+		yield();
 	}
 	return sum / times;
 }

--- a/HX711.h
+++ b/HX711.h
@@ -22,7 +22,12 @@ class HX711
 		// gain: 128 or 64 for channel A; channel B works with 32 gain factor only
 		HX711(byte dout, byte pd_sck, byte gain = 128);
 
+		HX711();
+
 		virtual ~HX711();
+
+		// Allows to set the pins and gain later than in the constructor
+		void begin(byte dout, byte pd_sck, byte gain = 128);
 
 		// check if HX711 is ready
 		// from the datasheet: When output data is not ready for retrieval, digital output pin DOUT is high. Serial clock

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ http://www.dfrobot.com/image/data/SEN0160/hx711_english.pdf
 Other libraries exist, including this very good one, which I first used and which is the starting point for my library:
 https://github.com/aguegu/ardulibs/tree/master/hx711
 
+# Advantages of this library
 Although other libraries exist, I needed a slightly different approach, so here's how my library is different than others:
 
 1. It provides a tare() function, which "resets" the scale to 0. Many other implementations calculate the tare weight when the ADC is initialized only. I needed a way to be able to set the tare weight at any time. Use case: place an empty container on the scale, call tare() to reset the readings to 0, fill the container and get the weight of the content.
@@ -21,10 +22,13 @@ Although other libraries exist, I needed a slightly different approach, so here'
 
 5. The "get_value" and "get_units" functions can receive an extra parameter "times", and they will return the average of multiple readings instead of a single reading.
 
-How to Calibrate Your Scale
+# How to Calibrate Your Scale
 
 1. Call set_scale() with no parameter.
 2. Call tare() with no parameter.
 3. Place a known weight on the scale and call get_units(10).
 4. Divide the result in step 3 to your known weight. You should get about the parameter you need to pass to set_scale.
 5. Adjust the parameter in step 4 until you get an accurate reading.
+
+# How to use
+See the examples section for possible implementations with the different constructors

--- a/examples/HX711SerialBegin/HX711SerialBegin.ino
+++ b/examples/HX711SerialBegin/HX711SerialBegin.ino
@@ -1,0 +1,59 @@
+#include "HX711.h"
+
+HX711 scale;
+
+void setup() {
+  Serial.begin(38400);
+  Serial.println("HX711 Demo");
+
+  Serial.println("Initializing the scale");
+  // parameter "gain" is ommited; the default value 128 is used by the library
+  // HX711.DOUT	- pin #A1
+  // HX711.PD_SCK	- pin #A0
+  scale.begin(A1, A0);
+
+  Serial.println("Before setting up the scale:");
+  Serial.print("read: \t\t");
+  Serial.println(scale.read());			// print a raw reading from the ADC
+
+  Serial.print("read average: \t\t");
+  Serial.println(scale.read_average(20));  	// print the average of 20 readings from the ADC
+
+  Serial.print("get value: \t\t");
+  Serial.println(scale.get_value(5));		// print the average of 5 readings from the ADC minus the tare weight (not set yet)
+
+  Serial.print("get units: \t\t");
+  Serial.println(scale.get_units(5), 1);	// print the average of 5 readings from the ADC minus tare weight (not set) divided
+						// by the SCALE parameter (not set yet)
+
+  scale.set_scale(2280.f);                      // this value is obtained by calibrating the scale with known weights; see the README for details
+  scale.tare();				        // reset the scale to 0
+
+  Serial.println("After setting up the scale:");
+
+  Serial.print("read: \t\t");
+  Serial.println(scale.read());                 // print a raw reading from the ADC
+
+  Serial.print("read average: \t\t");
+  Serial.println(scale.read_average(20));       // print the average of 20 readings from the ADC
+
+  Serial.print("get value: \t\t");
+  Serial.println(scale.get_value(5));		// print the average of 5 readings from the ADC minus the tare weight, set with tare()
+
+  Serial.print("get units: \t\t");
+  Serial.println(scale.get_units(5), 1);        // print the average of 5 readings from the ADC minus tare weight, divided
+						// by the SCALE parameter set with set_scale
+
+  Serial.println("Readings:");
+}
+
+void loop() {
+  Serial.print("one reading:\t");
+  Serial.print(scale.get_units(), 1);
+  Serial.print("\t| average:\t");
+  Serial.println(scale.get_units(10), 1);
+
+  scale.power_down();			        // put the ADC in sleep mode
+  delay(5000);
+  scale.power_up();
+}


### PR DESCRIPTION
This is the implementation of the ideas in #29 where it was discussed to move the definition of the pins from the initial constructor. This for example allows to wrap the library in a task for [Makuna/Task](https://github.com/Makuna/Task) as shown [here](https://github.com/SirUli/Task-Examples) for other sensors.

While i was on it, i added two yields to fix the ESP8266 Watchdog Resets (this does not change the behaviour on other platforms but helps to prevent unwanted resets).

For the testing of my changes i have added a second example with the new approach to the constructor. And i have executed the tests with the added .travis.yml - so you could now signup for [Travis](https://travis-ci.org/) and have a Continuous Integration for free.

Hope this is useful for you.

Cheers,
Uli