### PR TITLE
Reflect issue #29 within the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,5 @@ Although other libraries exist, I needed a slightly different approach, so here'
 5. Adjust the parameter in step 4 until you get an accurate reading.
 
 # How to use
-See the examples section for possible implementations with the different constructors
+See the example in examples/HX711SerialBegin. Please don't use examples/HX711Serial anymore. It is deprecated because the pin definition within the constructor
+is not timing safe. (#29)


### PR DESCRIPTION
Hi,

yesterday I suddenly struggled with WDT issues in my sketches that worked very well before. After a long research finally I found out the reason: Issue #29 
The explanations within the thread and in the links sound so reasonable, that I propose to explicitly add it to the readme. Maybe we should even consider to rename the example to something like HX711Serial-deprecated or even remove it?