### PR TITLE
'set_gain' returns the last value of 'read'

### DIFF
--- a/HX711.cpp
+++ b/HX711.cpp
@@ -25,7 +25,7 @@ bool HX711::is_ready() {
 	return digitalRead(DOUT) == LOW;
 }
 
-void HX711::set_gain(byte gain) {
+long HX711::set_gain(byte gain) {
 	switch (gain) {
 		case 128:		// channel A, gain factor 128
 			GAIN = 1;
@@ -39,7 +39,8 @@ void HX711::set_gain(byte gain) {
 	}
 
 	digitalWrite(PD_SCK, LOW);
-	read();
+	// read one more value with old gain/channel to update settings
+	return read();
 }
 
 long HX711::read() {

--- a/HX711.h
+++ b/HX711.h
@@ -34,10 +34,10 @@ class HX711
 		// input PD_SCK should be low. When DOUT goes to low, it indicates data is ready for retrieval.
 		bool is_ready();
 
-		// set the gain factor; takes effect only after a call to read()
+		// set the gain factor; read() is invoked to set the new gain and its return value is returned
 		// channel A can be set for a 128 or 64 gain; channel B has a fixed 32 gain
 		// depending on the parameter, the channel is also set to either A or B
-		void set_gain(byte gain = 128);
+		long set_gain(byte gain = 128);
 
 		// waits for the chip to be ready and returns a reading
 		long read();


### PR DESCRIPTION
When two load cells are connected to one HX711 it is a trivial use case to read both channels in a loop. Currently it looks something like this:

```arduino
void loop() {
  scale.set_gain(64);
  long loadA = scale.read();
  scale.set_gain(32);
  long loadB = scale.read();
  // Do something with readings...
}
```

In such scenario, under the hood there are 4 calls to `read` which slow down everything significantly.

With this change, this use case can be solved efficiently with:

```arduino
void loop() {
  long loadB = scale.set_gain(32);
  long loadA = scale.set_gain(64);
  // Do something with readings...
}
```

I know that it an awefull interface to work with, as the `set_scale` method already does too many things. However, I couldn't find a better yet simple way to both read and update efficiently. If you have a better solution I would like to hear!

Note that this change shouldn't break existing code (AFAIK, I'm not a C++ dev).