### PR TITLE
Define “yield” as noop for older Arduino Core releases

### DIFF
--- a/HX711.cpp
+++ b/HX711.cpp
@@ -1,6 +1,12 @@
 #include <Arduino.h>
 #include <HX711.h>
 
+#if ARDUINO_VERSION <= 106
+    // "yield" is not implemented as noop in older Arduino Core releases, so let's define it.
+    // See also: https://stackoverflow.com/questions/34497758/what-is-the-secret-of-the-arduino-yieldfunction/34498165#34498165
+    void yield(void) {};
+#endif
+
 HX711::HX711(byte dout, byte pd_sck, byte gain) {
 	begin(dout, pd_sck, gain);
 }


### PR DESCRIPTION
When trying to build against an ancient Arduino release (1.0.6) we got errors like:

    HX711.cpp:54:9: error: ‘yield’ was not declared in this scope
    HX711.cpp:92:9: error: ‘yield’ was not declared in this scope

This PR just defines the `yield` function for the old SDK conditionally by testing against `ARDUINO_VERSION <= 106`.