### PR TITLE
Fix yield for ESP8266

### DIFF
--- a/HX711.cpp
+++ b/HX711.cpp
@@ -7,6 +7,10 @@
     void yield(void) {};
 #endif
 
+#ifdef ARDUINO_ARCH_ESP8266
+  #define USE_WDT
+#endif
+
 HX711::HX711(byte dout, byte pd_sck, byte gain) {
 	begin(dout, pd_sck, gain);
 }
@@ -52,7 +56,11 @@ long HX711::read() {
 	// wait for the chip to become ready
 	while (!is_ready()) {
 		// Will do nothing on Arduino but prevent resets of ESP8266 (Watchdog Issue)
+    #ifdef USE_WDT
+    ESP.wdtFeed();
+    #else
 		yield();
+    #endif
 	}
 
 	unsigned long value = 0;
@@ -90,7 +98,11 @@ long HX711::read_average(byte times) {
 	long sum = 0;
 	for (byte i = 0; i < times; i++) {
 		sum += read();
+    #ifdef USE_WDT
+    ESP.wdtFeed();
+    #else
 		yield();
+    #endif
 	}
 	return sum / times;
 }

--- a/HX711.cpp
+++ b/HX711.cpp
@@ -1,7 +1,7 @@
 #include <Arduino.h>
 #include <HX711.h>
 
-#if ARDUINO_VERSION <= 106
+#ifndef ARDUINO_ARCH_ESP8266
     // "yield" is not implemented as noop in older Arduino Core releases, so let's define it.
     // See also: https://stackoverflow.com/questions/34497758/what-is-the-secret-of-the-arduino-yieldfunction/34498165#34498165
     void yield(void) {};


### PR DESCRIPTION
Hi,

The yield code seems to make my ESP's crash. The ESP has a watch dog timer feed function for long running processes. I have implemented this for the ESP8266 only by using macros. I have tested this on the ESP8266, but I did not check if it has any side effects for other boards.

Cheers!