### PR TITLE
Change yield(); to delay(0); because esp8266 2.4.0-rc2 wdt resets.

### DIFF
--- a/HX711.cpp
+++ b/HX711.cpp
@@ -52,7 +52,7 @@ long HX711::read() {
 	// wait for the chip to become ready
 	while (!is_ready()) {
 		// Will do nothing on Arduino but prevent resets of ESP8266 (Watchdog Issue)
-		yield();
+		delay(0);
 	}
 
 	unsigned long value = 0;


### PR DESCRIPTION
yield(); in esp8266 2.4.0-rc2 not prevent resets but delay(0); prevent. I install library in esp8266 and it non stop restarts until i change yield() to delay(0); and library start working :)