### PR TITLE
Read straight into long

### DIFF
--- a/HX711.cpp
+++ b/HX711.cpp
@@ -56,32 +56,19 @@ long HX711::read() {
 	}
 
 	unsigned long value = 0;
-	uint8_t data[3] = { 0 };
-	uint8_t filler = 0x00;
 
 	// pulse the clock pin 24 times to read the data
-	data[2] = shiftIn(DOUT, PD_SCK, MSBFIRST);
-	data[1] = shiftIn(DOUT, PD_SCK, MSBFIRST);
-	data[0] = shiftIn(DOUT, PD_SCK, MSBFIRST);
+	for (int i = 0; i <24; i++){
+		digitalWrite(PD_SCK,HIGH);
+		value |= digitalRead(DOUT) << (24-i);
+		digitalWrite(PD_SCK,LOW);
+	}
 
 	// set the channel and the gain factor for the next reading using the clock pin
 	for (unsigned int i = 0; i < GAIN; i++) {
 		digitalWrite(PD_SCK, HIGH);
 		digitalWrite(PD_SCK, LOW);
 	}
-
-	// Replicate the most significant bit to pad out a 32-bit signed integer
-	if (data[2] & 0x80) {
-		filler = 0xFF;
-	} else {
-		filler = 0x00;
-	}
-
-	// Construct a 32-bit signed integer
-	value = ( static_cast<unsigned long>(filler) << 24
-			| static_cast<unsigned long>(data[2]) << 16
-			| static_cast<unsigned long>(data[1]) << 8
-			| static_cast<unsigned long>(data[0]) );
 
 	return static_cast<long>(value);
 }


### PR DESCRIPTION
Saves reading of bytes and construction of 32 bit int, doesn't require calling of ShiftIn