### PR TITLE
Fix "clean" target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,4 +59,4 @@ ci-basic:
 	$(platformio) ci --board=$(board) --lib="." examples/HX711_basic_example --verbose
 
 clean:
-	platformio run -t clean
+	$(platformio) run -t clean


### PR DESCRIPTION
@rohlan spotted a minor glitch while #123 has been merged already. This is the straggler.