### PR TITLE
Update #include directive in HX711.cpp

### DIFF
--- a/src/HX711.cpp
+++ b/src/HX711.cpp
@@ -8,7 +8,7 @@
  *
 **/
 #include <Arduino.h>
-#include <HX711.h>
+#include "HX711.h"
 
 // TEENSYDUINO has a port of Dean Camera's ATOMIC_BLOCK macros for AVR to ARM Cortex M3.
 #define HAS_ATOMIC_BLOCK (defined(ARDUINO_ARCH_AVR) || defined(TEENSYDUINO))


### PR DESCRIPTION
In response to Issue #149 and #104 this commit changes the #include directive for hx711.h to solve compilation issues. 

The #include <HX711.h> directive caused a compilation failure because I did not have (nor did I wish to have) this library installed as part of my IDE. I resolved it as suggested by @MarioJose by replacing the directive to #include "HX711.h".

The problem arose because I cloned the git repo as a submodule into another git repo; this instead of installing the libraries in the IDE so that I can easily port my code between machines (and users) without having to have each instance configure the IDE and install the dependencies.