### PR TITLE
Prevent sketch lock-up if read (or begin) fail

### DIFF
--- a/src/HX711.cpp
+++ b/src/HX711.cpp
@@ -102,7 +102,9 @@ void HX711::set_gain(byte gain) {
 long HX711::read() {
 
 	// Wait for the chip to become ready.
-	wait_ready();
+  if ( !wait_ready_retry() ){
+    return 0;
+  }
 
 	// Define structures for reading data into.
 	unsigned long value = 0;

--- a/src/HX711.h
+++ b/src/HX711.h
@@ -45,7 +45,7 @@ class HX711
 
 		// Wait for the HX711 to become ready
 		void wait_ready(unsigned long delay_ms = 0);
-		bool wait_ready_retry(int retries = 3, unsigned long delay_ms = 0);
+		bool wait_ready_retry(int retries = 100, unsigned long delay_ms = 5);
 		bool wait_ready_timeout(unsigned long timeout = 1000, unsigned long delay_ms = 0);
 
 		// set the gain factor; takes effect only after a call to read()


### PR DESCRIPTION
This solves an issue where a sketch/board that does not have a properly connected HX711 locks up.
This solution returns a zero value to tell the downstream code that there was an error.