### PR TITLE
Unpull DOUT pin for ESPRESSIF boards

### DIFF
--- a/src/HX711.cpp
+++ b/src/HX711.cpp
@@ -73,7 +73,7 @@ void HX711::begin(byte dout, byte pd_sck, byte gain) {
 	DOUT = dout;
 
 	pinMode(PD_SCK, OUTPUT);
-	pinMode(DOUT, INPUT_PULLUP);
+	pinMode(DOUT, INPUT);
 
 	set_gain(gain);
 }

--- a/src/HX711.cpp
+++ b/src/HX711.cpp
@@ -61,6 +61,13 @@ uint8_t shiftInSlow(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder) {
 #define SHIFTIN_WITH_SPEED_SUPPORT(data,clock,order) shiftIn(data,clock,order)
 #endif
 
+#ifdef ARCH_ESPRESSIF
+// ESP8266 doesn't read values between 0x20000 and 0x30000 when DOUT is pulled up.
+#define DOUT_MODE INPUT
+#else
+#define DOUT_MODE INPUT_PULLUP
+#endif
+
 
 HX711::HX711() {
 }
@@ -73,7 +80,7 @@ void HX711::begin(byte dout, byte pd_sck, byte gain) {
 	DOUT = dout;
 
 	pinMode(PD_SCK, OUTPUT);
-	pinMode(DOUT, INPUT);
+	pinMode(DOUT, DOUT_MODE);
 
 	set_gain(gain);
 }


### PR DESCRIPTION
I've tested multiple ESP8266 modules and all fail to pull correct value from HX711 in range from 0x20000 to 0x30000 (instead it reads just a bit below 0x20000). When load cell is pushed hard enough, reading immediately jumps from a bit below 0x20000 to a bit above 0x30000.
```
#include <HX711.h>

HX711 loadcell;

void setup() {
  loadcell.begin(14, 12);
  Serial.begin(9600);
}

void loop() {
  Serial.println(loadcell.get_units());
}
```
Changing DOUT mode from INPUT_PULLUP to INPUT fixes the issue.
I've also tested multiple Arduino Nano modules and they all function properly regardless DOUT mode.