### PR TITLE
Add CMakeLists.txt for Arduino as a ESP-IDF component.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,4 @@
+
+idf_component_register(SRCS "src/HX711.cpp"
+                       INCLUDE_DIRS "src"
+                       REQUIRES "arduino")


### PR DESCRIPTION
Hi,

Request to add CMakeLists.txt so that HX711 library can be directly used as an ESP-IDF component as described by the build system documentation:
[https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html)

Similar to, and in conjunction with, Arduino as a ESP-IDF component:
[https://docs.espressif.com/projects/arduino-esp32/en/latest/esp-idf_component.html](https://docs.espressif.com/projects/arduino-esp32/en/latest/esp-idf_component.html)

I also have a working example that is tested on an ESP32 development board, happy to add that to another pull request or this one.
