### PR TITLE
provide a function to read out current GAIN setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@
 # PlatformIO virtualenv and pioenv
 /.venv*
 /.pioenvs
+.pio
+.vscode

--- a/src/HX711.cpp
+++ b/src/HX711.cpp
@@ -256,6 +256,10 @@ void HX711::set_scale(float scale) {
 	SCALE = scale;
 }
 
+byte HX711::get_gain() {
+	return GAIN;
+}
+
 float HX711::get_scale() {
 	return SCALE;
 }

--- a/src/HX711.h
+++ b/src/HX711.h
@@ -72,6 +72,9 @@ class HX711
 		// set the SCALE value; this value is used to convert the raw data to "human readable" data (measure units)
 		void set_scale(float scale = 1.f);
 
+		// get the current GAIN
+		byte get_gain();
+
 		// get the current SCALE
 		float get_scale();
 


### PR DESCRIPTION
Hi (Andreas Motl) - my first pull request. We would like to query the class for its current GAIN setting so that measurements can be scaled up appropriately in the calling program.

If that works with you, I'll soon submit one more regarding a small program bug and a new function that provides an average reading but omits the largest and smallest reading.