### PR TITLE
Fixed gpio not configured as pullup for non espressif boards.

### DIFF
--- a/src/HX711.cpp
+++ b/src/HX711.cpp
@@ -61,7 +61,7 @@ uint8_t shiftInSlow(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder) {
 #define SHIFTIN_WITH_SPEED_SUPPORT(data,clock,order) shiftIn(data,clock,order)
 #endif
 
-#ifdef ARCH_ESPRESSIF
+#if ARCH_ESPRESSIF
 // ESP8266 doesn't read values between 0x20000 and 0x30000 when DOUT is pulled up.
 #define DOUT_MODE INPUT
 #else


### PR DESCRIPTION
Fixes issue https://github.com/bogde/HX711/issues/232.